### PR TITLE
Send rescued errors to Sentry

### DIFF
--- a/lib/workers/sync_personal_email.rb
+++ b/lib/workers/sync_personal_email.rb
@@ -32,6 +32,7 @@ module Workers
         end
       rescue StandardError => err
         TrogdirChangeErrorWorker.perform_async(sync_log_id, err.message)
+        Raven.capture_exception(err) if defined? Raven
       end
     end
   end


### PR DESCRIPTION
We were just sending them to trogdir. But sentry gives us notifications and more details on the error, so it's nice to have both.